### PR TITLE
add benchmark for Settings.toInternal + optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/segmentio/go-hll
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/settings_test.go
+++ b/settings_test.go
@@ -136,3 +136,14 @@ func resetDefaults() {
 	defaultSettings = nil
 	defaultSettingsLock.Unlock()
 }
+
+func BenchmarkSettingsToInternal(b *testing.B) {
+	s := Settings{
+		Log2m:    11,
+		Regwidth: 5,
+	}
+
+	for i := 0; i < b.N; i++ {
+		s.toInternal()
+	}
+}


### PR DESCRIPTION
Adds a benchmark and cleaned up a tiny bit of code. Clean code runs fast apparently 😛
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkSettingsToInternal-12     64.0          31.9          -50.16%

benchmark                          old allocs     new allocs     delta
BenchmarkSettingsToInternal-12     0              0              +0.00%

benchmark                          old bytes     new bytes     delta
BenchmarkSettingsToInternal-12     0             0             +0.00%
```